### PR TITLE
Create SIP-0007.md

### DIFF
--- a/SIP-0007.md
+++ b/SIP-0007.md
@@ -1,0 +1,7 @@
+SIP 0007 – Proposal to transfer RBTC raised during the Genesis Pre-order from Bitocracy 1.0 to Bitocracy 2.0
+It is proposed that:
+
+1.	The funds being held by the vault contract of bitocracy 1.0 as RBTC (0xc7a1637b37190a456b017897207bceb2A29f19b9) are moved to the vesting registry contract of Bitocracy 2.0 (0x80b036ae59b3e38b573837c01bb1dB95515b7e6b).
+2.	This vesting contract will allow cSOV holders to either redeem their investment or exchange their cSOV for SOV as set out in SIP-0005.
+3.	Bitocracy 2.0 remains in control of this contract and can withdraw the remaining RBTC at any time.
+


### PR DESCRIPTION
SIP 0007 – Proposal to transfer RBTC raised during the Genesis Pre-order from Bitocracy 1.o to Bitocracy 2.0
It is proposed that:

1.	The funds being held by the vault contract of bitocracy 1.0 as RBTC (0xc7a1637b37190a456b017897207bceb2A29f19b9) are moved to the vesting registry contract of Bitocracy 2.0 (0x80b036ae59b3e38b573837c01bb1dB95515b7e6b).
2.	This vesting contract will allow cSOV holders to either redeem their investment or exchange their cSOV for SOV as set out in SIP-0005.
3.	Bitocracy 2.0 remains in control of this contract and can withdraw the remaining RBTC at any time.

