### PR TITLE
Proposed clarification to Incentive Payouts

### DIFF
--- a/SIP-0024.md
+++ b/SIP-0024.md
@@ -6,7 +6,7 @@ If approved, this proposal will:
 
 1. Reward "marginal stakers" (ie, stakers by choice, not currently vesting) with liquid SOV at the beginning of each new staking interval.
 2. Grant the Exchequer the authority to utilize liquid SOV from the treasury emitted from the Adoption Fund for this trial incentive program lasting for a period of six staking intervals (app. three months).
-3. Grant the Exchequer (based on the analysis of user / usage data gathered during the program) the authority to cancel, or extend the incentive program for additional 3 month intervals, until such time as the Exchequer determines such incentives are no longer meaningful.
+3. Grant the Exchequer (based on the analysis of user / usage data gathered during the program) the authority to cancel, or extend the incentive program for additional 3 month intervals, until such time as the Exchequer determines such incentives are no longer meaningful. The incentives offered upon staking will survive changes introduced by the Exchequer at a later date. A staked position that would, for example, earn 30% based on the incentive structure that existed upon creation of the stake lock-up, should continue to earn that 30% until the stake lock-up expires. 
 
 ## Motivation:
 
@@ -21,7 +21,7 @@ If approved, this proposal will:
 
 ## Technical implementation
 
-1. A script will be executed at the beginnng of each new staking interval every second Friday which will distribute liquid SOV to eligible users.
+1. A script will be executed at the begining of each new staking interval every second Friday which will distribute liquid SOV to eligible users.
 2. The liquid SOV will be added to the users’ claimable balances on the lockedSOV contract with an unlockedImmediatelyPercent of 100%. This means the SOV will not be added to a vesting contract like other incentive programs, but will be transferred to the user directly on claiming.
 
 ## The Formula


### PR DESCRIPTION
Point 3. of the description states:

"Grant the Exchequer (based on the analysis of user / usage data gathered during the program) the authority to cancel, or extend the incentive program for additional 3 month intervals, until such time as the Exchequer determines such incentives are no longer meaningful." 

To my reading, this opens up the possibility that a user would stake for a period (eg. 3 years) under the expectation that the rewards would continue for the entire length of their stake. However, with the current wording, it would appear that if the exchequer did not renew the program, that the rewards would cease. 

I therefore have proposed changed language which would prevent this from happening. I have proposed the addition:
"The incentives offered upon staking will survive changes introduced by the Exchequer at a later date. A staked position that would, for example, earn 30% based on the incentive structure that existed upon creation of the stake lock-up, should continue to earn that 30% until the stake lock-up expires."

Also, minor spelling mistake corrected.