### PR TITLE
SIP-28: Add SOV as collateral for borrowing

### DIFF
--- a/SIP-28.md
+++ b/SIP-28.md
@@ -21,10 +21,10 @@ A 300% collateralization ratio is proposed due to the relative immaturity and vo
 
 ## Proposed change
 
-Add SOV as collateral when borrowing, with the following parameters:
+Add SOV as system-wide collateral for borrowing any asset supported on Sovryn, with the following parameters:
 - SOV token contract address: `0xefc78fc7d48b64958315949279ba181c2114abbd`  
 - Collateralization rate: 300%  
-- Oracle: Sovryn SOV/RBTC AMM pool TWAP  
+- Oracle: Sovryn SOV/RBTC AMM pool TWAP `0x756d751d09B67d8Fc98be892431926Ff3F70a991`  
 
 ## License
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/SIP-28.md
+++ b/SIP-28.md
@@ -17,6 +17,8 @@ If approved, this proposal would enable SOV holders to use their SOV as collater
 
 Adding SOV as a collateral asset in the loan protocol would give SOV holders a way to gain liquidity from their SOV holdings without having to sell their SOV. A side effect of this is that it would enable SOV holders to go "leverage long" SOV by borrowing against their SOV collateral and using the proceeds of the loan to buy more SOV.
 
+A 300% collateralization ratio is proposed due to the relative immaturity and volatility of SOV as an asset. This is compared to the 150% collateralization required when using RBTC as collateral.
+
 ## Proposed change
 
 Add SOV as collateral when borrowing, with the following parameters:

--- a/SIP-28.md
+++ b/SIP-28.md
@@ -1,5 +1,5 @@
 ---
-SIP: N/A
+SIP: 28
 Title: Add SOV as collateral for borrowing
 Author: John Light (@john-light)
 Status: Draft
@@ -7,7 +7,7 @@ Track: Parameter
 Created: 2021-09-03
 ---
 
-# SIP-X: Add SOV as collateral for borrowing
+# SIP-28: Add SOV as collateral for borrowing
 
 ## Description
 

--- a/SIP-X.md
+++ b/SIP-X.md
@@ -1,0 +1,28 @@
+---
+SIP: N/A
+Title: Add SOV as collateral for borrowing
+Author: John Light (@john-light)
+Status: Draft
+Track: Parameter
+Created: 2021-09-03
+---
+
+# SIP-X: Add SOV as collateral for borrowing
+
+## Description
+
+If approved, this proposal would enable SOV holders to use their SOV as collateral when borrowing using Sovryn.
+
+## Motivation
+
+Adding SOV as a collateral asset in the loan protocol would give SOV holders a way to gain liquidity from their SOV holdings without having to sell their SOV. A side effect of this is that it would enable SOV holders to go "leverage long" SOV by borrowing against their SOV collateral and using the proceeds of the loan to buy more SOV.
+
+## Proposed change
+
+Add SOV as collateral when borrowing, with the following parameters:
+- SOV token contract address: `0xefc78fc7d48b64958315949279ba181c2114abbd`  
+- Collateralization rate: 300%  
+- Oracle: Sovryn SOV/RBTC AMM pool TWAP  
+
+## License
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Current draft for `SIP-28: Add SOV as collateral for borrowing`.

### 📜 Read the current draft [here](https://github.com/DistributedCollective/SIPS/blob/b3fb05c38450955c0c9117df202ff5fefeaecec6/SIP-28.md).

### 🗣 Comment on the current draft [here](https://github.com/DistributedCollective/SIPS/pull/28/files).
- If you comment on a line that already has a comment thread, please start a new comment thread unless your comment is relevant to the existing thread.
- You can share general comments or questions as a response below.  
- There is a thread in the Sovryn forum that you can also use to share your comments [here](https://forum.sovryn.app/t/sip-28-add-sov-as-collateral-for-borrowing/1651).